### PR TITLE
修复自定义绘图模型尺寸无法修改的问题

### DIFF
--- a/src/Desktop/RodelAgent.UI/ViewModels/Items/DrawModelItemViewModel.cs
+++ b/src/Desktop/RodelAgent.UI/ViewModels/Items/DrawModelItemViewModel.cs
@@ -45,6 +45,7 @@ public sealed partial class DrawModelItemViewModel : ViewModelBase<DrawModel>
         {
             Name = dialog.Model.DisplayName;
             Id = dialog.Model.Id;
+            Data.SupportSizes = dialog.Model.SupportSizes;
         }
     }
 


### PR DESCRIPTION
## Close #26 

## 描述

原因在于关闭自定义模型对话框时没有存储修改后的尺寸信息

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
