### PR TITLE
修复对话模型选择记忆没有生效的问题

### DIFF
--- a/src/Desktop/RodelAgent.UI/ViewModels/Pages/ChatServicePageViewModel/ChatServicePageViewModel.Sessions.cs
+++ b/src/Desktop/RodelAgent.UI/ViewModels/Pages/ChatServicePageViewModel/ChatServicePageViewModel.Sessions.cs
@@ -276,7 +276,7 @@ public sealed partial class ChatServicePageViewModel
     {
         ExitGroupChat();
         CurrentSession?.SaveSessionToDatabaseCommand.ExecuteAsync(default);
-        var defaultModel = SettingsToolkit.ReadLocalSetting($"{serviceVM.ProviderType}DefaultModel", string.Empty);
+        var defaultModel = SettingsToolkit.ReadLocalSetting($"{serviceVM.ProviderType}DefaultChatModel", string.Empty);
         var hasModel = !string.IsNullOrEmpty(defaultModel) && (serviceVM.ServerModels.Any(p => p.Id == defaultModel) || serviceVM.CustomModels.Any(p => p.Id == defaultModel));
         if (!hasModel)
         {


### PR DESCRIPTION
## Close #24 

## 描述

用户每次手动选择的模型都会作为下一次新会话的默认模型。

这个设置没有生效是因为在编写代码期间设置名没有匹配。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
