### PR TITLE
修复创建 agent 时删除初始消息的匹配问题

### DIFF
--- a/src/Core/RodelChat.Models/Client/ChatMessage.cs
+++ b/src/Core/RodelChat.Models/Client/ChatMessage.cs
@@ -140,7 +140,15 @@ public sealed class ChatMessage
         => Content.FirstOrDefault()?.Text ?? string.Empty;
 
     /// <inheritdoc/>
-    public override bool Equals(object? obj) => obj is ChatMessage message && EqualityComparer<DateTimeOffset?>.Default.Equals(Time, message.Time);
+    public override bool Equals(object? obj)
+    {
+        if (obj is not ChatMessage message)
+        {
+            return false;
+        }
+
+        return Time == message.Time && GetFirstTextContent() == message.GetFirstTextContent() && Role == message.Role;
+    }
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Time);


### PR DESCRIPTION
## 描述

在创建 Agent 的初始对话消息时，由于没有设置时间戳，这会导致删除消息时的匹配出现问题（想删除第二个，结果删除了第一个）

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
