### PR TITLE
提高会话加载性能

### DIFF
--- a/src/Desktop/RodelAgent.UI/ViewModels/Components/ChatSessionViewModel/ChatSessionViewModel.cs
+++ b/src/Desktop/RodelAgent.UI/ViewModels/Components/ChatSessionViewModel/ChatSessionViewModel.cs
@@ -69,8 +69,16 @@ public sealed partial class ChatSessionViewModel : ViewModelBase<ChatSession>
         CheckChatEmpty();
         CheckLastMessageTime();
         CheckRegenerateButtonShown();
-        CalcTotalTokenCount();
         RequestFocusInput?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// 在进入视图开始显示时执行.
+    /// </summary>
+    [RelayCommand]
+    private void EnterView()
+    {
+        CalcTotalTokenCount();
     }
 
     [RelayCommand]
@@ -158,6 +166,12 @@ public sealed partial class ChatSessionViewModel : ViewModelBase<ChatSession>
     [RelayCommand]
     private void CalcTotalTokenCount()
     {
+        var pageVM = GlobalDependencies.ServiceProvider.GetService<ChatServicePageViewModel>();
+        if (pageVM.CurrentSession != this)
+        {
+            return;
+        }
+
         CalcBaseTokenCount();
         CalcUserInputTokenCount();
     }

--- a/src/Desktop/RodelAgent.UI/ViewModels/Pages/ChatServicePageViewModel/ChatServicePageViewModel.cs
+++ b/src/Desktop/RodelAgent.UI/ViewModels/Pages/ChatServicePageViewModel/ChatServicePageViewModel.cs
@@ -132,6 +132,16 @@ public sealed partial class ChatServicePageViewModel : ViewModelBase
         CheckGroupPanelType();
     }
 
+    partial void OnCurrentSessionChanged(ChatSessionViewModel value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        value.EnterViewCommand.Execute(default);
+    }
+
     partial void OnIsServiceColumnManualHideChanged(bool value)
         => SettingsToolkit.WriteLocalSetting(SettingNames.IsChatServicePageServiceColumnManualHide, value);
 


### PR DESCRIPTION
## Close #59 

## 描述

在引入 Tiktoken 后，由于错误的调用，会导致加载服务/助理时会将会话历史里的所有会话的TOKEN都计算一遍，造成巨大的延迟。

现在增加了限制，只会在加载当前会话时计算当前会话的token，不会再额外计算其它会话。

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
