### PR TITLE
🐛 fix: 修复助理创建时服务切换没有更新模型列表的问题

### DIFF
--- a/src/Desktop/RodelAgent.UI/Controls/Chat/ChatAgentModelPanel.xaml
+++ b/src/Desktop/RodelAgent.UI/Controls/Chat/ChatAgentModelPanel.xaml
@@ -136,11 +136,14 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
             <ComboBox
+                x:Name="ServiceComboBox"
                 Margin="0,0,0,12"
                 HorizontalAlignment="Stretch"
                 Header="{ext:Locale Name=Services}"
                 ItemsSource="{x:Bind ViewModel.AvailableServices}"
-                SelectedItem="{x:Bind ViewModel.SelectedService, Mode=TwoWay}">
+                SelectedItem="{x:Bind ViewModel.SelectedService, Mode=OneWay}"
+                SelectionChanged="OnServiceSelectionChanged"
+                SelectionChangedTrigger="Committed">
                 <ComboBox.ItemTemplate>
                     <DataTemplate x:DataType="vm:ChatServiceItemViewModel">
                         <Grid Padding="4" ColumnSpacing="8">

--- a/src/Desktop/RodelAgent.UI/Controls/Chat/ChatAgentModelPanel.xaml.cs
+++ b/src/Desktop/RodelAgent.UI/Controls/Chat/ChatAgentModelPanel.xaml.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Richasy. All rights reserved.
 
+using Richasy.WinUIKernel.AI.ViewModels;
 using Richasy.WinUIKernel.Share.Toolkits;
 using RodelAgent.Statics;
 using RodelAgent.UI.Toolkits;
@@ -144,4 +145,7 @@ public sealed partial class ChatAgentModelPanel : ChatAgentConfigControlBase
 
     private void OnEmojiAvatarButtonClick(object sender, RoutedEventArgs e)
         => FlyoutBase.ShowAttachedFlyout(sender as FrameworkElement);
+
+    private void OnServiceSelectionChanged(object sender, SelectionChangedEventArgs e)
+        => ViewModel.SelectServiceCommand.Execute(ServiceComboBox.SelectedItem as ChatServiceItemViewModel);
 }


### PR DESCRIPTION
## Close #105 

## 描述

在服务发生变动时响应更改，重载模型列表

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新
